### PR TITLE
Track multiple fem(s)' health status

### DIFF
--- a/control/config/hexitec_hardware.cfg
+++ b/control/config/hexitec_hardware.cfg
@@ -19,14 +19,14 @@ fem_0 =
     server_data_ip = 10.0.4.2,
     camera_data_ip = 10.0.4.1
 ; Testing purposes:
-; fem_1 = 
-;     ip_addr = 10.0.0.100,
-;     port = 1234,
-;     id = 5,
-;     server_ctrl_ip = 11.0.2.2,
-;     camera_ctrl_ip = 12.0.2.1,
-;     server_data_ip = 13.0.4.2,
-;     camera_data_ip = 14.0.4.1
+;fem_1 = 
+;    ip_addr = 10.0.0.100,
+;    port = 1234,
+;    id = 5,
+;    server_ctrl_ip = 11.0.2.2,
+;    camera_ctrl_ip = 12.0.2.1,
+;    server_data_ip = 13.0.4.2,
+;    camera_data_ip = 14.0.4.1
 
 [adapter.live_view]
 module = odin_data.live_view_adapter.LiveViewAdapter

--- a/control/src/hexitec/HexitecFem.py
+++ b/control/src/hexitec/HexitecFem.py
@@ -425,8 +425,8 @@ class HexitecFem():
             self.operation_percentage_complete = 0
             self._set_status_message("Connecting to camera..")
             self.cam_connect()
-            self._set_status_message("Camera connected. Waiting for VSRs' FPGAs \
-                to initialise..")
+            msg = "Camera connected. Waiting for VSRs' FPGAs to initialise.."
+            self._set_status_message(msg)
             self._wait_while_fpgas_initialise()
             self.initialise_progress = 0
         except ParameterTreeError as e:

--- a/control/src/hexitec/adapter.py
+++ b/control/src/hexitec/adapter.py
@@ -234,9 +234,12 @@ class Hexitec():
                 camera_data_ip_addr=defaults.fem["camera_data_ip"]
             ))
 
+        self.fem_health = {}
         fem_tree = {}
         for fem in self.fems:
             fem_tree["fem_{}".format(fem.id)] = fem.param_tree
+            # Populate fem(s) health dictionary
+            self.fem_health["fem_{}".format(fem.id)] = True
 
         # Bias (clock) tracking variables #
         self.bias_clock_running = False
@@ -297,7 +300,8 @@ class Hexitec():
                 "fem_id": (lambda: self.fem_id, None),
                 "system_health": (lambda: self.health, None),
                 "status_message": (lambda: self.status_message, None),
-                "status_error": (lambda: self.status_error, None)
+                "status_error": (lambda: self.status_error, None),
+                "fem_health": (lambda: self.fem_health, None)
             }
         })
 
@@ -339,6 +343,7 @@ class Hexitec():
             # TODO: Also check sensor values?
             # ..
             health = fem.get_health()
+            self.fem_health["fem_{}".format(fem.id)] = health
             # Only note current id if system is in health
             if self.health:
                 self.fem_id = fem.get_id()

--- a/control/test/hexitec/package/test_DAQ.py
+++ b/control/test/hexitec/package/test_DAQ.py
@@ -631,7 +631,8 @@ class TestDAQ(unittest.TestCase):
 
         # Create a meta-data group
         metadata_group = hdf_file.create_group("hexitec")
-
+        self.test_daq.daq.calibration_enable = True
+        self.test_daq.daq.threshold_mode = "filename"
         self.test_daq.daq.write_metadata(metadata_group, self.test_daq.parameter_dict)
 
         hdf_file.close()


### PR DESCRIPTION
    Each fem's health tracked individually by adapter (previously just one single Boolean)
    Covers missing couple of lines of test_DAQ unit test
    Fixes a message string in HexitecFem unintentionally spanning two lines.