### PR TITLE
Implement Odin-data's End of Acquisition Frame

### DIFF
--- a/control/src/hexitec/adapter.py
+++ b/control/src/hexitec/adapter.py
@@ -714,6 +714,12 @@ class Hexitec():
         """
         for fem in self.fems:
             fem.stop_acquisition = True
+
+        # Inject End of Acquisition Frame
+        command = "config/inject_eoa"
+        request = ApiAdapterRequest("", content_type="application/json")
+        self.adapters["fp"].put(command, request)
+
         self.shutdown_processing()
 
     def _collect_offsets(self, msg):
@@ -724,10 +730,6 @@ class Hexitec():
     def commit_configuration(self, msg):
         """Push HexitecDAQ's 'config/' ParameterTree settings into FP's plugins."""
         self.daq.commit_configuration()
-        # # DEBUGGING ONLY: Ensure fudge for everyone(!)
-        # self.first_initialisation  = True
-        # self.fems[0].first_initialisation  = True
-        # self.daq.first_initialisation = True
 
     def get_server_uptime(self):
         """

--- a/control/test/hexitec/package/test_DAQ.py
+++ b/control/test/hexitec/package/test_DAQ.py
@@ -466,8 +466,10 @@ class TestDAQ(unittest.TestCase):
             self.test_daq.daq.parent.fems[0].hardware_busy = True
             self.test_daq.daq.frame_end_acquisition = 10
             self.test_daq.daq.shutdown_processing = True
+            self.test_daq.daq.frames_processed = 0
             self.test_daq.daq.processing_check_loop()
-            mock_loop.instance().add_callback.assert_called_with(self.test_daq.daq.stop_acquisition)
+            assert self.test_daq.daq.file_writing is False
+            assert self.test_daq.daq.shutdown_processing is False
 
     def test_processing_check_loop_polling_while_data_being_processed(self):
         """Test processing check loop polls itself while data coming in."""

--- a/control/test/hexitec/package/test_adapter.py
+++ b/control/test/hexitec/package/test_adapter.py
@@ -617,6 +617,14 @@ class TestDetector(unittest.TestCase):
 
     def test_cancel_acquisition(self):
         """Test function can cancel (in software) ongoing acquisition."""
+        self.test_adapter.detector.daq.configure_mock(
+            in_progress=False
+        )
+
+        self.test_adapter.detector.fems[0].bias_voltage_refresh = False
+        self.test_adapter.detector.first_initialisation = True
+        self.test_adapter.detector.adapters = self.test_adapter.adapters
+        print(self.test_adapter.adapters)
         self.test_adapter.detector.fems[0].stop_acquisition = False
         self.test_adapter.detector.cancel_acquisition()
 

--- a/data/frameProcessor/include/HexitecHistogramPlugin.h
+++ b/data/frameProcessor/include/HexitecHistogramPlugin.h
@@ -78,6 +78,7 @@ namespace FrameProcessor
       std::string sensors_layout_str_;
       HexitecSensorLayoutMap sensors_layout_;
 
+      void process_end_of_acquisition();
       void process_frame(boost::shared_ptr<Frame> frame);
 
       void add_frame_data_to_histogram_with_sum(float *frame);

--- a/data/frameProcessor/include/HexitecReorderPlugin.h
+++ b/data/frameProcessor/include/HexitecReorderPlugin.h
@@ -63,6 +63,7 @@ namespace FrameProcessor
 
       void process_lost_packets(boost::shared_ptr<Frame>& frame);
       void process_frame(boost::shared_ptr<Frame> frame);
+
       // Float type array version currently used:
       void reorder_pixels(unsigned short *in, float *out);
       // Convert pixels from unsigned short to float type without reordering

--- a/data/frameProcessor/src/HexitecHistogramPlugin.cpp
+++ b/data/frameProcessor/src/HexitecHistogramPlugin.cpp
@@ -292,6 +292,17 @@ namespace FrameProcessor
     return true;
   }
 
+  /** Process an EndOfAcquisitionFrame.
+  *
+  * Write histograms to disk on end of acquisition
+  */
+  void HexitecHistogramPlugin::process_end_of_acquisition()
+  {
+    LOG4CXX_INFO(logger_, "End of acquisition frame received, writing histograms to disk");
+    writeHistogramsToDisk();
+    frames_processed_ = 0;
+  }
+
   /**
    * Perform processing on the frame.  Calculate histograms based upon
    * each frame, writing resulting datasets to file when configured


### PR DESCRIPTION
        Histograms now flushed out if acquisition cancelled by user
        Can be expanded to cover watchdog timeouts in the future.