### PR TITLE
Add GUI keyboard shortcuts

### DIFF
--- a/control/static/index.html
+++ b/control/static/index.html
@@ -135,12 +135,12 @@
                 </div>
               </td>
               <td>
-                <input type="button" class="btn btn-primary" id='connectButton' data-size="small" value="Connect">
-                <input type="button" class="btn btn-primary" id='initialiseButton' data-size="small" value="Initialise">
-                <input type="button" class="btn btn-primary" id='offsetsButton' data-size="small" value="Collect Offsets">
-                <input type="button" class="btn btn-primary" id='acquireButton' data-size="small" value="Acquire">
-                <input type="button" class="btn btn-primary" id='cancelButton' data-size="small" value="Cancel">
-                <input type="button" class="btn btn-primary" id='disconnectButton' data-size="small" value="Disconnect">
+                <input type="button" accesskey="c" class="btn btn-primary" id='connectButton' data-size="small" value="Connect">
+                <input type="button" accesskey="n" class="btn btn-primary" id='initialiseButton' data-size="small" value="Initialise">
+                <input type="button" accesskey="l" class="btn btn-primary" id='offsetsButton' data-size="small" value="Collect Offsets">
+                <input type="button" accesskey="q" class="btn btn-primary" id='acquireButton' data-size="small" value="Acquire">
+                <input type="button" accesskey="x" class="btn btn-primary" id='cancelButton' data-size="small" value="Cancel">
+                <input type="button" accesskey="i" class="btn btn-primary" id='disconnectButton' data-size="small" value="Disconnect">
               </td>
             </tr>
             <tr>
@@ -187,7 +187,7 @@
                           <b>Auto&#8209;update:</b> 
                         </div>
                         <div class="col-xs-7">
-                          <input type="checkbox" name="liveview_enable" data-size="small">
+                          <input type="checkbox" accesskey="v" name="liveview_enable" data-size="small">
                         </div>
                       </div>
                       <div class="row sidebar-row vertical-align">
@@ -277,7 +277,7 @@
               <td>
                 <div class="row sidebar-row vertical-align">
                   <div class="col-xs-7">
-                    <input type="checkbox" id='rawDataButton' name="raw_data_enable" data-size="small">
+                    <input type="checkbox" accesskey="w" id='rawDataButton' name="raw_data_enable" data-size="small">
                   </div>
                 </div>
               </td>
@@ -290,7 +290,7 @@
               <td>
                 <div class="row sidebar-row vertical-align">
                   <div class="col-xs-7">
-                    <input type="checkbox" id='processedDataButton' name="processed_data_enable" data-size="small">
+                    <input type="checkbox" accesskey="p" id='processedDataButton' name="processed_data_enable" data-size="small">
                   </div>
                 </div>
               </td>
@@ -585,7 +585,7 @@
                 &nbsp;
               </td>
               <td>
-                <input type="button" class="btn btn-primary double-width" id='applyButton' data-size="small" value="Apply All">
+                <input type="button" accesskey="y" class="btn btn-primary double-width" id='applyButton' data-size="small" value="Apply All">
               </td>
             </tr>
           </table>


### PR DESCRIPTION
    UI must be opened with Google Chrome, no support in Firefox.
    Alt+[0] where [0] replaced by letter in brackets for the controls:
    Connect (c), Initialise (n), Collect Offsets (l), Acquire (q)
    Cancel (x), Disconnect (j), Raw Dataset (w), Processed Dataset (p),
    Apply All (y), Live View (v).
    Best approximate keys chosen as certain keys reserved by browser.